### PR TITLE
Update ruby,vagrant image, fixes for fedora 31

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ The script is currently designed in the following way:
 - The script makes some suppositions
   - Vagrant is installed
   - Ansible is installed in your host machine
-  - Virtualbox is installed
+  - Virtualbox or other virtualization solution is installed
 
 ## The process ##
 
-The Vagrant file will create a VM using fedora25-cloud as a basis and proceed to configure it for development:
+The Vagrant file will create a VM using fedora31-cloud as a basis and proceed to configure it for development:
 - Configure the VM with 6 GB and 2 CPU
 - Open port 3000 for UI management
 - Open port 4000 for API management
@@ -20,7 +20,7 @@ The Vagrant file will create a VM using fedora25-cloud as a basis and proceed to
 - Install python (needed by Ansible) so the Ansible playbook.yml can be run
 - Configure the OS and install everything needed for development
 - Configure the database, start and enable it and add the user needed
-- Configure rbenv and install ruby 2.3.1
+- Configure rbenv and install ruby 2.6.5
 - Verify if reboot is necessary and then reboot the machine
 
 ## Limitations ##

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,19 +7,7 @@ ENV['VAGRANT_DEFAULT_PROVIDER'] = 'virtualbox'
 # backwards compatibility). Please don't change it unless you know what
 # you're doing.
 Vagrant.configure(2) do |config|
-  # The most common configuration options are documented and commented below.
-  # For a complete reference, please see the online documentation at
-  # https://docs.vagrantup.com.
-
-  # Every Vagrant development environment requires a box. You can search for
-  # boxes at https://atlas.hashicorp.com/search.
-  config.vm.box = "fedora/25-cloud-base"
-
-  # Disable automatic box update checking. If you disable this, then
-  # boxes will only be checked for updates when the user runs
-  # `vagrant box outdated`. This is not recommended.
-  # config.vm.box_check_update = false
-
+  config.vm.box = "fedora/31-cloud-base"
   # Create a forwarded port mapping which allows access to a specific port
   # within the machine from a port on the host machine. In the example below,
   # accessing "localhost:8080" will access port 80 on the guest machine.
@@ -28,41 +16,15 @@ Vagrant.configure(2) do |config|
   config.vm.network "forwarded_port", guest: 4000, host: 4000
   #config.vm.network "forwarded_port", guest: 443, host: 13443
 
-  # Create a private network, which allows host-only access to the machine
-  # using a specific IP.
-  # config.vm.network "private_network", ip: "192.168.33.10"
-
-  # Create a public network, which generally matched to bridged network.
-  # Bridged networks make the machine appear as another physical device on
-  # your network.
-  # config.vm.network "public_network"
-
-  # Share an additional folder to the guest VM. The first argument is
-  # the path on the host to the actual folder. The second argument is
-  # the path on the guest to mount the folder. And the optional third
-  # argument is a set of non-required options.
-  # config.vm.synced_folder "../data", "/vagrant_data"
-  # config.vm.synced_folder "~/workspace/manageiq", "/manageiq"
-
-  # Provider-specific configuration so you can fine-tune various
-  # backing providers for Vagrant. These expose provider-specific options.
-  # Example for VirtualBox:
-  #
-  # config.vm.provider "virtualbox" do |vb|
-  #   # Display the VirtualBox GUI when booting the machine
-  #   vb.gui = true
-  #
-  #   # Customize the amount of memory on the VM:
-  #   vb.memory = "1024"
-  # end
-  #
-  # View the documentation for the provider you are using for more
-  # information on available options.
-
   config.vm.provider "virtualbox" do |vb|
      vb.memory = 6144
      vb.cpus = 2
      vb.name = "manageiq-dev"
+  end
+  
+  config.vm.provider "libvirt" do |vm|
+     vm.memory = 6144
+     vm.cpus = 2
   end
 
   config.vm.hostname = "miqdev"
@@ -77,21 +39,6 @@ Vagrant.configure(2) do |config|
   config.vm.provision "ansible" do |ansible|
     ansible.playbook = "scripts/playbook.yml"
   end
-
-  # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
-  # such as FTP and Heroku are also available. See the documentation at
-  # https://docs.vagrantup.com/v2/push/atlas.html for more information.
-  # config.push.define "atlas" do |push|
-  #   push.app = "YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME"
-  # end
-
-  # Enable provisioning with a shell script. Additional provisioners such as
-  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
-  # documentation for more information about their specific syntax and use.
-  # config.vm.provision "shell", inline: <<-SHELL
-  #   sudo apt-get update
-  #   sudo apt-get install -y apache2
-  # SHELL
 
   config.vm.provision "shell", privileged: false, inline: <<-EOF
     echo "Vagrant Box provisioned!"

--- a/scripts/initiation.sh
+++ b/scripts/initiation.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-dnf -y install python python2-dnf
+dnf -y install python

--- a/scripts/playbook.yml
+++ b/scripts/playbook.yml
@@ -28,9 +28,10 @@
         - libcurl-devel
         - npm
         - openssl-devel
+        - make
         - cmake
         - python-psycopg2
-        - libselinux-python
+        - libselinux
         - bash-completion
         - vim
     - name: install npm packages needed
@@ -57,7 +58,7 @@
       postgresql_user: name=root password=smartvm state=present role_attr_flags=SUPERUSER
 - hosts: all
   vars:
-    ruby_version: "2.3.1"
+    ruby_version: "2.6.5"
   become: false
   tasks:
     - name: git clone rbenv
@@ -79,10 +80,8 @@
       command: dnf needs-restarting
       register: reboot_needed
     - name: reboot machine
-      shell: shutdown -t 5 -r now "Rebooting as the appliance needs restarting"
-      async: 0
-      poll: 0
-      ignore_errors: yes
+      reboot:
+        reboot_timeout: 180
       when: reboot_needed.stdout != ""
     - name: waiting for server to come back
       wait_for_connection:


### PR DESCRIPTION
Problems:

The fedora25/cloud-base image is unavailable.
Ruby 2.3.X is too old.
Not all packages are available, also `make` is required.

Solution:
Use a newer fedora31\cloud-base image.
Use ruby 2.6.5 (it's still supported, it's not the newest but works [I didn't try 2.7.1]).
Remove python2-dnf (dnf is default and python2 is outdated).
Change a playbook a little bit. Also, use `reboot` module instead of the old way to reboot the machine.

I also removed most of the comments from Vagrantfile and added support for libvirt.

When this PR would be accepted, I will make changes to guides repo.