### PR TITLE
Fedora 33 as base image

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,7 +7,7 @@ ENV['VAGRANT_DEFAULT_PROVIDER'] = 'virtualbox'
 # backwards compatibility). Please don't change it unless you know what
 # you're doing.
 Vagrant.configure(2) do |config|
-  config.vm.box = "fedora/31-cloud-base"
+  config.vm.box = "fedora/33-cloud-base"
   # Create a forwarded port mapping which allows access to a specific port
   # within the machine from a port on the host machine. In the example below,
   # accessing "localhost:8080" will access port 80 on the guest machine.

--- a/scripts/playbook.yml
+++ b/scripts/playbook.yml
@@ -18,7 +18,6 @@
         - bzip2 
         - libffi-devel
         - readline-devel
-        - libxml
         - libxml2-devel
         - libxslt-devel
         - patch
@@ -72,7 +71,7 @@
     - name: ruby version to be used
       lineinfile: dest=~/.bashrc line='export RBENV_VERSION="{{ ruby_version }}"'
     - name: install ruby version {{ ruby_version }}
-      shell: rbenv install -s {{ ruby_version }}
+      shell: source ~/.bashrc; rbenv install -s {{ ruby_version }}
 - hosts: all
   become: true
   tasks:


### PR DESCRIPTION
- more recent Fedora release
- `libxml` doesn't seem to be necessary
- fixed `rbenv install` command execution in local Ansible

Above changes have been tested with `ansible_local` and verified working on Mac OSX Big Sur. However, at the end of the playbook, it tries to reboot the VM, and it fails. I'm not sure if it's possible from inside the VM running in Vagrant/VirtualBox.
